### PR TITLE
Swap Navigation item "Events" to "Calendar"

### DIFF
--- a/_data/header_nav.yml
+++ b/_data/header_nav.yml
@@ -21,8 +21,8 @@ blog:
     en: /news/
 events:
   name:
-    de: Events
-    en: Events
+    de: Kalendar
+    en: Calendar
   link:
     de: /kalender/
     en: /calendar/


### PR DESCRIPTION
If a website visitor wants to discover the Comaking space, they will want to see the usual opening hours. Those are described in the calendar, which is accessed by the navigation item Events.
A visitor would expect "events" to describe special events (yearly meeting, special seminar, etc...), not usual activities.
A calendar is expected to cover both.